### PR TITLE
Add upstream data downloading and analysis

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,17 @@ jobs:
       - uses: actions/setup-python@v2
       - name: Setup Pages
         uses: actions/configure-pages@v2
-      
-      # Install dependencies and build site
+
+
+      # Install dependencies
       - run: pip install -r requirements.txt
+
+      # Download the latest GitHub data
+      - run: python book/scripts/download_github_data.py
+        env:
+          TOKEN_GITHUB_READONLY: ${{ secrets.TOKEN_GITHUB_API_READONLY }}
+
+      # Build the site
       - run: sphinx-build book book/_build/html
         env:
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Sphinx
 */_build
+
+# Data files bundled with this tool that we don't want to check in
+book/data/github-activity.csv

--- a/book/data/key-communities.yml
+++ b/book/data/key-communities.yml
@@ -1,0 +1,4 @@
+- "jupyter"
+- "jupyterhub"
+- "executablebooks"
+- "2i2c-org"

--- a/book/data/team.yml
+++ b/book/data/team.yml
@@ -1,0 +1,8 @@
+- "choldgraf"
+- "colliand"
+- "georgianaelena"
+- "jmunroe"
+- "yuvipanda"
+- "consideRatio"
+- "sgibson91"
+- "damianavila"

--- a/book/index.md
+++ b/book/index.md
@@ -3,6 +3,10 @@
 This is a lightweight website to visualize some of 2i2c's Key Performance Indicators.
 Its goal is to quickly let us look at the most important numbers to gauge the health and impact of our organization.
 
+These dashboards are generated with [Jupyter Book](https://jupyterbook.org) and the [MyST Markdown stack](https://myst.tools).
+These are tools from the [ExecutableBooks project](https://executablebooks.org), one of 2i2c's key upstream communities.
+
 ```{toctree}
 finances
+upstream
 ```

--- a/book/scripts/download_github_data.py
+++ b/book/scripts/download_github_data.py
@@ -1,0 +1,132 @@
+from github_activity import get_activity
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+import pandas as pd
+import numpy as np
+import os
+from yaml import safe_load
+from pathlib import Path
+from copy import deepcopy
+
+# Define here based on whether we're interactive
+if "__file__" in globals():
+    here = Path(__file__).parent
+else:
+    here = Path(".")
+
+# Load data that we'll use for visualization
+communities = safe_load((here / "../data/key-communities.yml").read_text())
+team = safe_load((here / "../data/team.yml").read_text())
+
+# If data already exists locally, load it
+datetime_columns = ["createdAt", "updatedAt", "closedAt"]
+path_data = Path(here / "../data/github-activity.csv")
+if path_data.exists():
+    data = pd.read_csv(path_data, parse_dates=datetime_columns)
+else:
+    data = None
+
+# +
+##
+# Determine which dates we need to grab new data
+##
+# We only want the last 3 months, so figure out our start and end dates
+# If we already have data, then the start date is:
+#    whatever is later of (last data date, and today - 3 months)
+# Use two quarters of data
+N_DAYS = 180
+today = datetime.now(tz=ZoneInfo("UTC"))
+time_window_begin = today - timedelta(days=N_DAYS)
+time_window_end = today
+
+# By default, we search 90 days in the past until the present
+if data is not None:
+    max_in_data = data["updatedAt"].max()
+    if max_in_data > time_window_begin:
+        time_window_begin = max_in_data  
+
+# Uncomment this to manually define a start date
+# start = datetime(2023, 1, 10, tzinfo=ZoneInfo("UTC"))
+# -
+
+# Break up our time window into windows of 60 days
+# This helps us avoid hitting the 1000 node limit in GitHub API
+time_breakpoints = []
+time_window_checkpoint = deepcopy(time_window_begin)
+while time_window_checkpoint < time_window_end:
+    time_breakpoints.append(time_window_checkpoint)
+    time_window_checkpoint += timedelta(days=60)
+time_breakpoints.append(time_window_end)
+
+# Download latest batch of data from GitHub
+for community in communities:
+    if time_window_end > today:
+        print(f"time_window_end date {time_window_end} is less than {today}, no data to update...")
+        continue
+
+    # Download the data from GitHub using github_activity
+    # We do this in windows of 2 months and then concat in one DataFrame
+    data_new = []
+    for ii in range(1, len(time_breakpoints)):
+        start_time = time_breakpoints[ii-1]
+        stop_time = time_breakpoints[ii]
+        
+        # Check for GitHub api authentication tokens and raise an error if none exist
+        auth_keys = ["TOKEN_GITHUB_READONLY", "GITHUB_TOKEN"]
+        for key in auth_keys:
+            if key in os.environ:
+                auth = os.environ.get(key)
+                break
+            auth = None
+        if auth is None:
+            print("No GitHub authentication token found, you will hit the rate limit...")
+            print(f"Searched for these key names: {auth_keys}")
+
+        print(f"Downloading activity in {community} from {start_time:%Y-%m-%d} to {stop_time:%Y-%m-%d}")
+        data_new.append(get_activity(community, f"{start_time:%Y-%m-%d}", f"{stop_time:%Y-%m-%d}", auth=auth))
+    data_new = pd.concat(data_new)
+    
+    # Clean up some fields so they're easier to work with later
+    def _extract_node(item):
+        """Extract any data that is nested in GraphQL sections."""
+        if isinstance(item, dict):
+            if "edges" in item:
+                # It is a graphql list of edges
+                nodes = [ii["node"] for ii in item["edges"]]
+                return nodes
+            if "login" in item:
+                # It is a username
+                return item["login"]
+            if "oid" in item:
+                # It is a merge commit
+                return item["oid"]
+        else:
+            return item
+    data_new = data_new.applymap(_extract_node)
+    
+    # Extract values from a few special-case columns
+    data_new["mergedBy"]
+    
+    # Change datetime strings to objects
+    for col in datetime_columns:
+        data_new[col] = pd.to_datetime(data_new[col])
+        
+    # Save our final data or append it to pre-existing data
+    if data is None:
+        data = data_new
+    else:
+        # If there are duplicated rows (corresponding to unique IDs)
+        # Keep the latest one (which is the newest data)
+        data = pd.concat([data, data_new]).drop_duplicates("id", keep="last")
+
+
+# +
+# Remove data that is older than 3 months
+data = data.loc[data["updatedAt"] > time_window_begin]
+
+# Sort by id
+data = data.sort_values("id")
+
+# Save to CSV
+data.to_csv(path_data, index=False)
+print(f"Saved GitHub activity data to: {path_data.resolve()}")

--- a/book/upstream.md
+++ b/book/upstream.md
@@ -1,0 +1,228 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+mystnb:
+  remove_code_source: true
+  output_stderr: remove
+---
+
+# Upstream community activity
+
+This is a short visualization of the 2i2c team's activity in upstream repositories. Its goal is to give a high level indication of where we're spending our time in key upstream communities.
+
+```{admonition} Work in progress!
+This is a work in progress, so some of the GitHub search queries might be slightly off.
+Use this to get a high-level view, but don't read too much into the details.
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+from github_activity import get_activity
+from datetime import datetime, timedelta
+import pandas as pd
+import altair as alt
+import os
+from yaml import safe_load
+from pathlib import Path
+from subprocess import run
+import json
+from ast import literal_eval
+from IPython.display import Markdown
+```
+
++++ {"tags": ["remove-cell"]}
+
+## Load and prep data
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Load data that we'll use for visualization
+communities = safe_load(Path("data/key-communities.yml").read_text())
+team = safe_load(Path("data/team.yml").read_text())
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# If data already exists locally, load it
+path_data = Path("data/github-activity.csv")
+if path_data.exists():
+    DATETIME_COLUMNS = ["createdAt", "updatedAt", "closedAt"]
+    data = pd.read_csv(path_data, parse_dates=DATETIME_COLUMNS)
+else:
+    print("No data found, please run `python ../scripts/download_github_data.py`")
+```
+
+```{code-cell} ipython3
+# Drop the 2i2c-org community because it's not upstream
+data = data.query("org != '2i2c-org'")
+
+# This is an "earliest date" we'll use to cut off visualization
+earliest = data["updatedAt"].min()
+latest = data["updatedAt"].max()
+
+Markdown(f"Showing data from **{earliest:%Y-%m-%d}** to **{latest:%Y-%m-%d}**")
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Pull out the comments into our own dataframe
+new_comments = []
+for _, row in data.iterrows():
+    iicomments = pd.DataFrame(literal_eval(row["comments"]))
+    if iicomments.shape[0] > 0:
+        iicomments["author"] = iicomments["author"].map(lambda a: a["login"] if a is not None else None)
+        iicomments[["org", "repo"]] = row[["org", "repo"]]
+        new_comments.append(iicomments)
+comments = pd.concat(new_comments)
+
+# Only keep comments from our team members
+comments = comments.query("author in @team")
+
+for col in DATETIME_COLUMNS:
+    if col in comments:
+        comments[col] = pd.to_datetime(comments[col])
+
+# Remove comments outside of this window
+comments = comments.loc[comments["updatedAt"] > earliest]
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Helper functions for visualization
+def visualize_by_org_repo(df, title="", number=25, kind="involves"):
+    df_counts = df.groupby(["org", "repo"]).count().iloc[:, 0].sort_values(ascending=False)
+    df_counts.name = "count"
+    df_counts = df_counts.reset_index()
+    df_counts = df_counts.head(number)
+    df_counts["url"] = df_counts.apply(create_github_url, axis=1, kind=kind)
+    
+    ch = alt.Chart(df_counts, title=title).mark_bar().encode(
+        x=alt.X("repo", sort=alt.SortField("count", "descending")),
+        y="count",
+        color="org",
+        tooltip=["org", "repo", "count"],
+        href="url",
+    ).interactive()
+    return ch
+
+def create_github_url(row, kind="involves"):
+    """Add a link to a GitHub query for each type of issue."""
+    people = "+".join([f"{kind}%3A{person}" for person in team])
+    query = f"repo%3A{row['org']}%2F{row['repo']}+{people}+updated%3A{earliest:%Y-%m-%d}..{latest:%Y-%m-%d}"
+    url = f"https://github.com/search?q={query}"
+    return url
+
+def visualize_over_time(df, on="updatedAt", title=""):
+    """Visualize activity binned by time."""
+    df_time = (df
+        .groupby(["org"])
+        .resample("W", on=on)
+        .count()
+        .iloc[:, 0]
+    )
+    df_time.name = "count"
+    df_time = df_time.reset_index()
+    ch = alt.Chart(df_time, title=title, width=500).mark_bar(size=10).encode(
+        x=on,
+        y="count",
+        color="org",
+        tooltip=["org", "count"],
+    ).interactive()
+    return ch
+```
+
+## Comments by a 2i2c team member
+
+Comments are a reflection of where we're participating in conversations, discussions, brainstorming, guiding others, etc. They are a reflection of "overall activity" because comments tend to happen everywhere, and may not be associated with a specific change to the code.
+
+```{code-cell} ipython3
+visualize_over_time(comments.query("author in @team"), title="Comments made by a team member, over time")
+```
+
+Now we break it down by repository to visualize where this activity has been directed.
+
+```{tip}
+Click a bar to show a GitHub search that roughly corresponds to the underlying data.
+```
+
+```{code-cell} ipython3
+visualize_by_org_repo(comments, kind="commenter", title="Comments by a team member, by repository.")
+```
+
++++ {"tags": []}
+
+## Issues opened by team members
+
+This shows issues that a 2i2c team member has opened over time.
+This gives an idea of where we are noticing issues and suggesting improvements in upstream repositories.
+
+```{code-cell} ipython3
+issues = data.loc[["issues/" in ii for ii in data["url"].values]]
+issuesByUs = issues.dropna(subset="createdAt").query("author in @team")
+visualize_over_time(issuesByUs,on="closedAt", title="Issues opened by a team member, over time")
+```
+
+Now we break it down by repository to visualize where this activity has been directed.
+
+```{tip}
+Click a bar to show a GitHub search that roughly corresponds to the underlying data.
+```
+
+```{code-cell} ipython3
+visualize_by_org_repo(issuesByUs, "Issues opened by a team member, by repository", kind="author")
+```
+
++++ {"tags": []}
+
+## Merged PRs authored by team members
+
+Pull Requests that were authored by a 2i2c team member, and merged by anyone.
+This gives an idea of where we're committing code, documentation, and team policy improvements.
+
+```{code-cell} ipython3
+authoredByUs = data.dropna(subset="closedAt").query("author in @team")
+visualize_over_time(authoredByUs, on="closedAt", title="PRs authored by a team member that were merged, over time")
+```
+
+Now we break it down by repository to visualize where this activity has been directed.
+
+```{tip}
+Click a bar to show a GitHub search that roughly corresponds to the underlying data.
+```
+
+```{code-cell} ipython3
+visualize_by_org_repo(authoredByUs, kind="mergedBy", title="PRs authored by a team member that were merged, by repository")
+```
+
+## PRs merged by team members
+
+This gives an idea of which Pull Requests were **merged** by a team member (not necessarily authored). Merging Pull Requests is a reflection of reviewing and incorporating the work of _others_ as opposed to only our own work.
+
+```{code-cell} ipython3
+mergedByUs = data.dropna(subset="closedAt").query("mergedBy in @team")
+visualize_over_time(mergedByUs, on="closedAt", title="PRs merged by a team member, over time")
+```
+
+Now we break it down by repository to visualize where this activity has been directed.
+
+```{tip}
+Click a bar to show a GitHub search that roughly corresponds to the underlying data.
+```
+
+```{code-cell} ipython3
+visualize_by_org_repo(mergedByUs, title="PRs merged by a team member, by repository")
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ altair
 myst-nb
 pyairtable
 pandas
+github-activity
 git+https://github.com/2i2c-org/sphinx-2i2c-theme
 sphinx-design
 sphinx-togglebutton


### PR DESCRIPTION
This adds a dashboard to summarize our **upstream activity** over the last two quarters (6 months). It provides summary statistics over time, as well as broken down by repository. You can click the bar graphs and it'll open a github search that roughly corresponds to that bar's data. It focuses this on our three key stakeholder communities, jupyter, jupyterhub, and executablebooks.

[Here's a little video explainer for the dashboard in Slack](https://2i2c.slack.com/files/UKUUCELKX/F04KGEJ1WLW/screenshare_-_2023-01-19_5_29_17_pm.webm), since I can't share a live preview of the docs.

It visualizes these things:

- Comments we made over time, and by repo
- Issues that we opened over time, and by repo
- PRs that we authored and that were merged over time, and by repo
- PRs that _we merged_ over time, and by repo

The goal of this is to show where our team is putting its upstream support and activity. We can use it to show that we are indeed participating in these communities, and give an idea for where our effort is focused. 

It also adds a script that will scrape the last 6 months of GitHub data from these organizations **as well as `2i2c-org`**. The 2i2c-org data isn't used here (since it is not an upstream repository), but we could use it for a 2i2c analysis of activity in a new dashboard in the future.

### Examples

It's hard to preview this PR, so here are examples of what the plots look like:

![image](https://user-images.githubusercontent.com/1839645/213429497-6fca5624-e12d-447f-a01e-1f83a101b507.png)

![image](https://user-images.githubusercontent.com/1839645/213429505-011f7dfc-026a-45e8-a4df-7ead34049629.png)


### References

- Part of: https://github.com/2i2c-org/team-compass/issues/407