### PR TITLE
Add cloud activity page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,9 @@ jobs:
         env:
           TOKEN_GITHUB_READONLY: ${{ secrets.TOKEN_GITHUB_API_READONLY }}
 
+      # Download the latest hub activity data
+      - run: python book/scripts/download_github_data.py
+
       # Build the site
       - run: sphinx-build book book/_build/html
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 # Data files bundled with this tool that we don't want to check in
 book/data/github-activity.csv
+book/data/hub-activity.csv

--- a/book/cloud.md
+++ b/book/cloud.md
@@ -135,7 +135,7 @@ Active users broken down by each hub that we run.
 
 ```{code-cell} ipython3
 ---
-tags: [remove-input]
+tags: [remove-input, remove-stderr, remove-stdout]
 ---
 chs = []
 groups = df.query("cluster!='utoronto'").groupby("scale")

--- a/book/cloud.md
+++ b/book/cloud.md
@@ -1,0 +1,166 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+% CSS for the big numbers
+
+<style>
+.big-number .sd-card-text {
+    font-size: 3rem;
+}
+</style>
+
+# JupyterHub usage
+
+This displays the usage of our cloud infrastructure to give an understanding of our infrastructure setup and the communities that use it.
+
+Last updated: **{sub-ref}`today`**
+
+```{admonition} Data source
+:class: dropdown
+This data is pulled from these two sources:
+
+1. The list of our hubs and clusters is pulled from [our `infrastructure/` repository](https://github.com/2i2c-org/infrastructure/tree/master/config/clusters).
+2. The active users data stream produced by JupyterHub and exposed at `metrics/`.
+   [See this PR for the feature](https://github.com/jupyterhub/jupyterhub/pull/4214).
+```
+
+```{code-cell} ipython3
+---
+tags: [remove-cell]
+---
+
+import pandas as pd
+from pathlib import Path
+import altair as alt
+from textwrap import dedent
+from IPython.display import Markdown
+```
+
+## Load and munge data
+
+```{code-cell} ipython3
+---
+tags: [remove-cell]
+---
+# Load the data
+df = pd.read_csv("data/hub-activity.csv", index_col=0)
+
+# Remove the staging hubs since they are generally redundant
+df = df.loc[df["hub"].map(lambda a: "staging" not in a)]
+```
+
+## Number of hubs
+
+`````{code-cell} ipython3
+---
+tags: [remove-input]
+mystnb:
+  markdown_format: myst
+---
+# Basic stats about our number of hubs and clusters
+n_clusters = df["cluster"].nunique()
+n_hubs = df["hub"].nunique()
+
+Markdown(f"""
+````{{grid}}
+:class-container: big-number
+
+```{{grid-item-card}} Total clusters
+{n_clusters}
+```
+```{{grid-item-card}} Total hubs
+{n_hubs}
+```
+````
+""")
+`````
+
+### Number of hubs per cluster
+
+_excluding staging hubs_
+
+```{code-cell} ipython3
+---
+tags: [remove-input]
+---
+table_nhubs = df.groupby("cluster").agg({"hub": "nunique"}).sort_values("hub", ascending=False)
+table_nhubs.columns = ["Number of hubs"]
+table_nhubs.T
+```
+
+## Active users
+
+### Total active users
+
+Total active users across all of our hubs and communities.
+
+`````{code-cell} ipython3
+---
+tags: [remove-input]
+mystnb:
+  markdown_format: myst
+---
+grid = """
+````{grid}
+:class-container: big-number
+%s
+````
+"""
+scale_ordering = ["Daily", "Weekly", "Monthly"]
+interior = []
+for scale in scale_ordering:
+    users = df.query("scale==@scale")["users"].sum()
+    interior.append(dedent("""\
+    ```{grid-item-card} %s
+    %s
+    ```\
+    """ % (scale, users)))
+Markdown(grid % "\n".join(interior))
+`````
+
+### Active users by hub
+
+Active users broken down by each hub that we run.
+
+```{code-cell} ipython3
+---
+tags: [remove-input]
+---
+chs = []
+groups = df.query("cluster!='utoronto'").groupby("scale")
+for scale in scale_ordering:
+    idata = groups.get_group(scale)
+    ch = alt.Chart(idata, title=f"{scale} users").mark_bar().encode(
+        alt.X("users:Q", bin=True),
+        y='count()',
+        color="scale",
+        tooltip=["users", "hub"],
+    ).interactive()
+    chs.append(ch)
+alt.hconcat(*chs)
+```
+
+### Outlier hubs
+
+Table statistics for a few hand-picked outliers so they don't skew the data above.
+
+```{code-cell} ipython3
+---
+tags: [remove-input]
+---
+dftable = df.query("cluster=='utoronto'")[["hub", "scale", "users"]].sort_values("scale", key=lambda col: col.map(lambda a: scale_ordering.index(a)))
+dftable = dftable.set_index(["hub", "scale"]).unstack("scale")["users"][scale_ordering]
+dftable.columns.name = None
+dftable.style.set_caption("Usage data for outlier hub")
+```

--- a/book/index.md
+++ b/book/index.md
@@ -19,7 +19,7 @@ Our currently running infrastructure and active users over time.
 
 Our financial activity, including our costs and revenue broken down by category.
 ```
-```{grid-item-card} Upstream contributions 💗
+```{grid-item-card} Upstream support 💗
 :link: upstream
 :link-type: doc
 

--- a/book/index.md
+++ b/book/index.md
@@ -7,6 +7,12 @@ Its goal is to quickly let us look at the most important numbers to gauge the he
 These are tools from the [ExecutableBooks project](https://executablebooks.org), one of 2i2c's key upstream communities.
 
 ````{grid}
+```{grid-item-card} Cloud and hub usage ☁️
+:link: cloud
+:link-type: doc
+
+Our currently running infrastructure and active users over time.
+```
 ```{grid-item-card} Accounting analysis 📈
 :link: finances
 :link-type: doc
@@ -26,6 +32,7 @@ Below is a breakdown of the categories above with more information about their s
 ```{toctree}
 :maxdepth: 2
 
-finances
+cloud
 upstream
+finances
 ```

--- a/book/scripts/download_hub_activity.py
+++ b/book/scripts/download_hub_activity.py
@@ -61,6 +61,7 @@ with Progress() as progress:
             progress.update(p_hubs, description=f"Processing hub {hub_name}...")
             resp = urlopen(f'https://{hub["domain"]}/metrics').read()
             metrics = resp.decode().split("\n")
+
             # Search for jupyterhub_active_users lines and grab their values
             for iline in metrics:
                 if "jupyterhub_active_users" not in iline:
@@ -74,7 +75,8 @@ with Progress() as progress:
                             "cluster": cluster.split("/")[-1],
                             "hub": hub["domain"],
                             "scale": name,
-                            "users": users
+                            "users": users,
+                            "chart": hub["helm_chart"]
                         })
             progress.update(p_hubs, advance=1)
         progress.update(p_clusters, advance=1)
@@ -83,3 +85,4 @@ with Progress() as progress:
 df = pd.DataFrame(df)
 path_out = Path(__file__).parent / ".." / "data" / "hub-activity.csv"
 df.to_csv(path_out)
+print(f"Finished downloading hub activity data to {path_out}.")

--- a/book/scripts/download_hub_activity.py
+++ b/book/scripts/download_hub_activity.py
@@ -1,0 +1,85 @@
+"""
+Download activer user data from each of our JupyterHubs and save them to a CSV.
+This uses the cluster and hub data in our config folder, and grabs the active users
+data from the `metrics/` endpoint of each JupyterHub we run.
+
+ref: https://github.com/2i2c-org/infrastructure/tree/master/config/clusters
+"""
+from rich import print
+from rich.progress import Progress
+import pandas as pd
+from yaml import safe_load
+from io import BytesIO
+from urllib.request import urlopen
+from zipfile import ZipFile
+from pathlib import Path
+from glob import glob
+
+# TODO: In the future, we should download timeseries data from Prometheus so that
+#       we can visualize this over time. This will be a bit more complex so for now we
+#       just visualize the current data from each hub.
+#
+#       This comment has instructions for how to get the prometheus data:
+#       ref: https://github.com/2i2c-org/infrastructure/issues/1785#issuecomment-1308494647
+
+# Download the `infrastructure/` repository as a Zip file so we can inspect contents
+# For now we don't use a token because this *should* only be a single operation.
+URL_REPOSITORY_ZIP = "https://github.com/2i2c-org/infrastructure/archive/refs/heads/master.zip"
+with urlopen(URL_REPOSITORY_ZIP) as zipresp:
+    with ZipFile(BytesIO(zipresp.read())) as zfile:
+        zfile.extractall('./_build/data/')
+
+# These are the time scales that we know are in the hub's metrics
+search_time_scales = {"24h": "Daily", "7d": "Weekly", "30d": "Monthly"}
+
+clusters = glob("_build/data/infrastructure-master/config/clusters/*")
+clusters = list(filter(lambda a: a != "templates", clusters))
+
+df = []
+with Progress() as progress:
+    p_clusters = progress.add_task("Processing clusters...", total=len(clusters))
+    p_hubs = None
+    for cluster in clusters:
+        # Load the configuration for this cluster
+        cluster_yaml = Path(f"{cluster}/cluster.yaml")
+        if not cluster_yaml.exists():
+            print(f"Skipping folder {cluster} because no cluster.yaml file exists...")
+            continue
+        progress.update(p_clusters, description=f"Processing cluster {cluster.split('/')[-1]}...")
+        config = cluster_yaml.read_text()
+        config = safe_load(config)
+
+        # Set up progress bar for the hubs on this cluster
+        if p_hubs is None:
+            p_hubs = progress.add_task("Processing hubs...", total=len(config["hubs"]))
+        else:
+            progress.update(p_hubs, total=len(config["hubs"]), completed=0)
+
+        # Find the domain for this hub and grab its metrics
+        for hub in config["hubs"]:
+            hub_name = hub["domain"].replace(".2i2c.cloud", "")
+            progress.update(p_hubs, description=f"Processing hub {hub_name}...")
+            resp = urlopen(f'https://{hub["domain"]}/metrics').read()
+            metrics = resp.decode().split("\n")
+            # Search for jupyterhub_active_users lines and grab their values
+            for iline in metrics:
+                if "jupyterhub_active_users" not in iline:
+                    continue
+                    
+                # We expect three time scales per hub
+                for scale, name in search_time_scales.items():
+                    if scale in iline:
+                        users = int(float(iline.split()[-1]))
+                        df.append({
+                            "cluster": cluster.split("/")[-1],
+                            "hub": hub["domain"],
+                            "scale": name,
+                            "users": users
+                        })
+            progress.update(p_hubs, advance=1)
+        progress.update(p_clusters, advance=1)
+      
+# Convert to a to save as a CSV
+df = pd.DataFrame(df)
+path_out = Path(__file__).parent / ".." / "data" / "hub-activity.csv"
+df.to_csv(path_out)

--- a/book/upstream.md
+++ b/book/upstream.md
@@ -19,6 +19,8 @@ mystnb:
 
 This is a short visualization of the 2i2c team's activity in upstream repositories. Its goal is to give a high level indication of where we're spending our time in key upstream communities.
 
+Last updated: **{sub-ref}`today`**
+
 ```{admonition} Work in progress!
 This is a work in progress, so some of the GitHub search queries might be slightly off.
 Use this to get a high-level view, but don't read too much into the details.

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,6 @@ def docs(session):
     
     if "live" in session.posargs:
       session.install("sphinx-autobuild")
-      session.run(*split("sphinx-autobuild book book/_build/html"))
+      session.run(*split("sphinx-autobuild book book/_build/html --port 0"))
     else:
       session.run(*split("sphinx-build book book/_build/html"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ altair
 myst-nb
 pyairtable
 pandas
+ghapi
 github-activity
 git+https://github.com/2i2c-org/sphinx-2i2c-theme
 sphinx-design


### PR DESCRIPTION
This adds a cloud activity page, which pulls jupyterhub activity metrics from our `metrics/` endpoint! It is fairly simple for now, and only tracks our latest data from each hub, but is a start!

Here's an idea of what the dashboards look like (since we don't preview this PR):

![image](https://user-images.githubusercontent.com/1839645/217303396-df98afff-7001-4738-a399-b0750b04a87c.png)


![image](https://user-images.githubusercontent.com/1839645/217303514-47bbaa63-019f-4d8a-bed4-5e3b34f46a61.png)
