### PR TITLE
Fix our chart for the new accounting data structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 # Data files bundled with this tool that we don't want to check in
 book/data/github-activity.csv
 book/data/hub-activity.csv
+
+# A place to manually store data we use as part of data updating
+book/scripts/_data/

--- a/book/conf.py
+++ b/book/conf.py
@@ -4,6 +4,10 @@ extensions = ["myst_nb", "sphinx_design", "sphinx_togglebutton"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 only_build_toc_files = True
 
+myst_enable_extensions = [
+  "linkify",
+]
+
 html_title = "2i2c KPIs"
 html_theme = "sphinx_2i2c_theme"
 

--- a/book/finances.md
+++ b/book/finances.md
@@ -31,6 +31,7 @@ There are two data sources on this page, both of which are described in more det
 
 1. **CS&S's monthly accounting data dumps**.
    These contain every transaction that 2i2c has ever recorded with CS&S.
+   See [the data munging notebook for accounting data](scripts/munge_css_accounting_data.py) for information on how to update this data.
    See [our Team Compass Accounting page](https://compass.2i2c.org/en/latest/finance/accounting.html#raw-accounting-statements) for more information.
 2. **Revenue data in the `Invoices` AirTable**.
    It is synced from the CS&S AirTable that contains _all invoices for 2i2c_.

--- a/book/scripts/munge_css_accounting_data.py
+++ b/book/scripts/munge_css_accounting_data.py
@@ -1,0 +1,98 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.14.5
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# + [markdown] user_expressions=[]
+# # Clean CS&S accounting data for use with our AirTable
+#
+# ## Instructions
+#
+# - Download latest data from our [Accounting Statements Folder](https://docs.google.com/spreadsheets/d/1PDpPAed_q35n1-xSNN1U9tzZg7tzzBVfpmGYFqMOneQ/edit?usp=share_link)
+#   
+#   > For example, here's [the account transactions up to 2023/01/31](https://docs.google.com/spreadsheets/d/1PDpPAed_q35n1-xSNN1U9tzZg7tzzBVfpmGYFqMOneQ/edit#gid=686580753)).
+#   
+# - Move to the `_data` folder here
+# - Run this notebook
+# - The final cell will copy the munged data to your clipboard
+# - Paste this data to the [All Accounting Transactions](https://airtable.com/appbjBTRIbgRiElkr/tblDKGQFU0iEIa5Qb/viwAdsIgMwbqKDdZ0?blocks=hide) AirTable.
+# - Make sure to **completely replace** the table with this updated data.
+# -
+
+import pandas as pd
+from glob import glob
+
+# +
+# Read in the raw data which we'll need to clean a bit
+datafiles = glob("_data/*.csv")
+
+# First datafile will be the one with the latest date
+raw = pd.read_csv(datafiles[0], header=6).dropna(subset=["Date"])
+
+# +
+# Create a copy so we can modify it
+data = raw.copy()
+
+# Remove "totals" rows
+data = data.loc[~data["Date"].str.startswith("Total"), :]
+
+# Define an account codes dictionary based on the category rows
+category_rows = data.loc[data["Source"].isna(), :]
+category_mapping = {}
+for irow in category_rows["Date"].values:
+    key, val = irow.split(" ", 1)
+    category_mapping[int(key)] = val
+    
+# Remove the "summary" lines from our account codes
+data = data.dropna(subset=["Source"])
+
+# Update our data with these semantic account codes
+data["Category"] = [category_mapping[int(ii)] for ii in data["Account Code"].values]
+
+# Convert our `Net` column to a float instead of currency data
+for ix, irow in data.iterrows():
+    inet = irow["Net"]
+    if inet.startswith("("):
+        inet = f"-{inet}"
+    for ichar in [",", "(", ")"]:
+        inet = inet.replace(ichar, "")
+    
+    # Make inet a float to make sure it's possible
+    inet = float(inet)
+
+    # Add a type as revenue or cost
+    # Receivable Invoices can show up in a "costs" section where we are billing directly for costs
+    if "Receivable Invoice" in irow["Source"] or "Revenues" in irow["Category"]:
+        data.loc[ix, "Revenue"] = inet
+        data.loc[ix, "Cost"] = 0
+    else:
+        data.loc[ix, "Cost"] = inet
+        data.loc[ix, "Revenue"] = 0
+        
+data = data.drop(columns=["Net"])
+
+# + [markdown] user_expressions=[]
+# ## Copy to clipboard to paste into AirTable
+#
+# You should be able to just copy/paste the dataset into [this AirTable now](https://airtable.com/appbjBTRIbgRiElkr/tblDKGQFU0iEIa5Qb/viwAdsIgMwbqKDdZ0).
+# Make sure to delete the header row though.
+# -
+
+data.to_clipboard(index=False)
+
+# + [markdown] user_expressions=[]
+# ## If you want to preview the data
+# -
+
+data
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pandas
 ghapi
 github-activity
 git+https://github.com/2i2c-org/sphinx-2i2c-theme
+linkify-it-py
 rich
 sphinx-design
 sphinx-togglebutton


### PR DESCRIPTION
This updates our accounting KPIs page in the following main ways:

- It now works with the new structure that CS&S puts out for their accounting data.
- We now only show the last 6 months of data, to prevent this from being overwhelming
- Time now always moves in the same (left to right) direction