### PR TITLE
Fix and simplify accounting page

### DIFF
--- a/book/finances.md
+++ b/book/finances.md
@@ -27,16 +27,11 @@ Last updated: **{sub-ref}`today`**
 ```{note} Data sources
 :class: dropdown
 
-There are two data sources on this page, both of which are described in more detail [on our Accounting sources page](https://compass.2i2c.org/en/latest/finance/accounting.html).
+There are two data sources on this page, both of them are AirTable tables that are synced from CS&S data:
 
-1. **CS&S's monthly accounting data dumps**.
-   These contain every transaction that 2i2c has ever recorded with CS&S.
-   See [the data munging notebook for accounting data](scripts/munge_css_accounting_data.py) for information on how to update this data.
-   See [our Team Compass Accounting page](https://compass.2i2c.org/en/latest/finance/accounting.html#raw-accounting-statements) for more information.
-2. **Revenue data in the `Invoices` AirTable**.
-   It is synced from the CS&S AirTable that contains _all invoices for 2i2c_.
-   Includes all **invoices** but does not contain some revenue and costs. Excludes payments to employees as well as grant-based payments.
-   See [our Team Compass Accounting page](https://compass.2i2c.org/en/latest/finance/accounting.html#airtable-data) for more information.
+- **Accounting tables** are documented at {external:doc}`on our Accounting sources page <finance/accounting>`.
+- **Invoicing data** are documented at {external:doc}`on our Invoices and Contracts page <finance/contracts>`.
+
 ```
 
 +++ {"tags": ["remove-cell"], "user_expressions": []}
@@ -69,14 +64,12 @@ base = Base(api_key, base_id)
 # Imports that we'll use later
 import altair as alt
 import pandas as pd
-from IPython.display import Markdown
+from IPython.display import Markdown, display
 ```
 
 +++ {"user_expressions": []}
 
-## Overview of monthly cost and revenue
-
-Provides an overview of our costs, revenue, and burn rate.
+## Summary of cost and revenue
 
 ```{code-cell} ipython3
 :tags: [remove-cell]
@@ -84,9 +77,9 @@ Provides an overview of our costs, revenue, and burn rate.
 # Start date for the records we'll display
 from datetime import datetime, timedelta
 
-# Using 8 months because we display N-1 months in the viz, and the latest month tends to be not up to date
+# Using 7 months because the latest month tends to be not up to date
 # So this gives us N=6 months + 1 for the latest month.
-n_months = 8
+n_months = 7
 start_date = datetime.today() - timedelta(days=30*n_months)
 start_date = datetime(year=start_date.year, month=start_date.month, day=1)
 ```
@@ -103,9 +96,13 @@ accounts["Date"] = pd.to_datetime(accounts["Date"])
 
 # Only keep data within the last N months
 accounts = accounts.query("Date > @start_date")
+```
 
-# Rename `Net` so that we can add a proper Net later
-accounts = accounts.rename(columns={"Net": "Amount"})
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Renames
+accounts = accounts.rename(columns={"Net": "Amount", "Category without number": "Category"})
 
 # Re-categorize our old AWS and Google Cloud entries that were created before the "rebillable to customers" category existed
 cloud_charge_keywords = ["google cloud", "google*cloud", "cloud infrastructure", "aws", "amazong web services", "azure"]
@@ -138,7 +135,6 @@ overall_summary = accounts.copy()[["Date", "Cost", "Revenue"]]
 # Calculate the monthly net and cumulative remaining over time
 overall_summary = overall_summary.resample("M", on="Date").agg("sum").reset_index()
 overall_summary["Net"] = overall_summary["Revenue"] - overall_summary["Cost"]
-overall_summary["Cumulative"] = overall_summary["Net"].cumsum()
 
 # Flip cost so that it plots upside down
 overall_summary["Cost"] = -1 * overall_summary["Cost"]
@@ -151,32 +147,33 @@ overall_summary = overall_summary.melt(id_vars="Date", var_name="Category")
 :tags: [remove-input, remove-stderr, remove-stdout]
 
 # Plot net revenue, cumulative, and trend for next 6 months
-net = alt.Chart(overall_summary.replace({"Cumulative": "Cash on Hand"}), title="Financial Summary (present <--> past)", width=75)
-yformat = alt.Axis(format="$,f")
-y_domain = [overall_summary["value"].min() - 10000, overall_summary["value"].max() + 10000]
-yscale = alt.Scale(domain=y_domain)
-net_br = net.mark_bar().encode(
-    y=alt.Y("value", scale=yscale, axis=yformat),
-    x=alt.X("Category", sort=alt.Sort(["Revenue", "Cost", "Net", "Cash on Hand"])),
-    column=alt.Column("yearmonth(Date):O", spacing=5),
-    tooltip=["Category", "value"],
-    color=alt.Color(
-        "Category",
-        scale=alt.Scale(
-            domain=["Revenue", "Cost", "Net", "Cash on Hand"],
-            range=["lightgreen", "red", "lightgrey", "grey"],
-        ),
-    ),
-).interactive()
 
-net_br
+yformat = alt.Axis(format="$,f")
+
+plots = []
+for kind, color in zip(["Revenue", "Cost", "Net"], ["lightgreen", "red", "grey"]):
+    net = alt.Chart(overall_summary.query("Category == @kind"), title=f"Monthly {kind}", width=650)
+    net_br = net.mark_bar().encode(
+        y=alt.Y("value", axis=yformat),
+        x=alt.X("yearmonth(Date):O"),
+        tooltip=["Category", "value"],
+        color=alt.Color(
+            "Category",
+            scale=alt.Scale(
+                domain=[kind],
+                range=[color],
+            ),
+            legend=None,
+        ),
+    ).interactive()
+    display(net_br)
 ```
 
 +++ {"user_expressions": []}
 
 ## Costs
 
-Monthly costs broken down by major category.
+Monthly costs are based on accounting transactions, and broken down by major category.
 
 Costs are generated from CS&S's monthly accounting data dumps (see [data sources](#data-sources)).
 
@@ -294,6 +291,7 @@ ch.mark_bar().encode(
 
 ## Revenue
 
+Revenue is based on monthly invoicing data.
 See [data sources](#data-sources) for background on where this data comes from.
 
 +++ {"tags": ["remove-cell"], "user_expressions": []}
@@ -329,7 +327,8 @@ for col in numeric_cols:
     revenue.loc[:, col] = revenue[col].replace("[\$,]", "", regex=True).astype(float)
 
 # Renaming for convenience
-revenue = revenue.rename(columns={"Contract Type": "Category"})
+revenue = revenue.rename(columns={"Service Type (from Contracts)": "Category"})
+revenue.loc[:, "Category"] = revenue["Category"].map(lambda a: a[0])
 
 # Add a category so we can compare
 revenue.loc[:, "Kind"] = "revenue"
@@ -349,24 +348,36 @@ revenue_monthly = (
 ```{code-cell} ipython3
 :tags: [remove-input, remove-stderr]
 
+# Sum the revenue within each category
 ch = alt.Chart(revenue_monthly, width=CHART_WIDTH, title="Monthly revenue by category")
-bar = ch.mark_bar().encode(
+bar1 = ch.mark_bar().encode(
     x="yearmonth(Date):O",
     y="Amount",
     color="Category",
     tooltip=["Category", "Amount"],
 ).interactive()
-bar
+display(bar1)
+
+# Count the number of invoices within each category
+ch = alt.Chart(revenue_monthly, width=CHART_WIDTH, title="Number of invoices by category")
+bar2 = ch.mark_bar().encode(
+    x="yearmonth(Date):O",
+    y="count(Contact)",
+    color="Category",
+    tooltip=["Category", "count(Contact)"],
+).interactive()
+display(bar2)
 ```
 
 +++ {"user_expressions": []}
 
-Same plots but with `grants` removed because they skew the visualizations.
+Same revenue plot as above, but with `grants` removed because they skew the visualizations.
 
 ```{code-cell} ipython3
 :tags: [remove-input, remove-stderr]
 
-ch = alt.Chart(revenue_monthly.query("Category != 'Grant'"), width=CHART_WIDTH, title="Monthly revenue by category (no grants)")
+revenue_monthly_nogrants = revenue_monthly.loc[~revenue_monthly["Category"].str.contains("Grant")]
+ch = alt.Chart(revenue_monthly_nogrants, width=CHART_WIDTH, title="Monthly revenue by category (no grants)")
 bar = ch.mark_bar().encode(
     x="yearmonth(Date):O",
     y="Amount",
@@ -374,301 +385,4 @@ bar = ch.mark_bar().encode(
     tooltip=["Category", "Amount"],
 ).interactive()
 bar
-```
-
-+++ {"user_expressions": []}
-
-**Hub Service revenue** with a monthly average
-
-```{code-cell} ipython3
-:tags: [remove-cell, remove-stderr]
-
-# Calculate a rolling mean each month
-monthly_service_revenue = revenue_monthly.query("Category == 'Hub Service'")
-revenue_monthly_totals = monthly_service_revenue.resample("M", on="Date").sum()
-revenue_monthly_totals_means = revenue_monthly_totals.rolling(3, 1).mean().reset_index()
-revenue_monthly_totals_means["Date"] = pd.to_datetime(revenue_monthly_totals_means["Date"])
-
-# Remove the last month because it usually isn't yet updated with full data
-revenue_monthly_totals_means = revenue_monthly_totals_means.iloc[:-1]
-```
-
-```{code-cell} ipython3
-:tags: [remove-input]
-
-# Print out an average amount
-Markdown(
-    f"3-month average revenue from hub service and development: **${revenue_monthly_totals_means.iloc[-3:]['Amount'].mean():,.2f}**"
-)
-```
-
-```{code-cell} ipython3
-:tags: [remove-input, remove-stderr, remove-stdout]
-
-ch = alt.Chart(monthly_service_revenue, width=CHART_WIDTH, title="Monthly Hub Service Revenue with 3 month average")
-bar = ch.mark_bar().encode(
-    x="yearmonth(Date):O",
-    y="Amount",
-    color=alt.Color("Status", scale=alt.Scale(range=["grey", "lightgreen"])),
-    tooltip=["Category", "Amount"],
-).interactive()
-
-ch = alt.Chart(
-    revenue_monthly_totals_means, width=CHART_WIDTH,
-)
-line = ch.mark_line(color="black").encode(
-    x="yearmonth(Date):O",
-    y="Amount",
-)
-scatter = ch.mark_point(color="black").encode(
-    x="yearmonth(Date):O",
-    y="Amount",
-    tooltip=alt.Tooltip("Amount", format="$,.2f"),
-).interactive()
-
-bar + line + scatter
-```
-
-+++ {"tags": ["remove-cell"], "user_expressions": []}
-
-Broken down by anonymized paying community
-
-> **Note** The below cell is removed to avoid concerns about anonymity. We should define a policy about how / when we make the identity of our partner communities public.
-
-```{code-cell} ipython3
-:tags: [remove-cell]
-
-# FLAGS
-ANONYMIZE_NAMES = True
-
-# Group by month and payer ID to plot
-unique_names = revenue_monthly["Contact"].unique()
-sorted_names = (
-    revenue_monthly.groupby("Contact")
-    .sum("Amount")
-    .sort_values("Amount", ascending=False)
-    .index.values
-)
-replacement_names = {
-    name: f"Community partner {ii:2d}"
-    for name, ii in zip(sorted_names, range(1, len(sorted_names) + 1))
-}
-
-if ANONYMIZE_NAMES:
-    use_data = revenue_monthly.replace(replacement_names)
-    use_names = list(replacement_names.values())
-else:
-    use_data = revenue_monthly
-    use_names = sorted_names
-    
-# Only display the hub service since others are one-offs
-use_data = use_data.query("Category == 'Hub Service'")
-
-ch = alt.Chart(
-    use_data,
-    width=CHART_WIDTH,
-    title="Monthly revenue by payer",
-)
-bar = ch.mark_bar().encode(
-    x="yearmonth(Date):O",
-    y="Amount",
-    color=alt.Color(
-        "Contact:O",
-        scale=alt.Scale(scheme="rainbow"),
-        sort=use_names,
-    ),
-    order="Contact:Q",
-    tooltip=["Contact", "Amount"]
-).interactive()
-bar
-```
-
-+++ {"user_expressions": []}
-
-**Contract revenue as a percentage of monthly costs.**
-100% means that we have fully recovered our costs that month.
-
-```{code-cell} ipython3
-:tags: [remove-input, remove-stderr, remove-stdout]
-
-cost_by_month = cost_by_type.groupby("Date").agg({"Cost": "sum"})
-contract_revenue_and_costs_monthly = cost_by_month.join(revenue_monthly_totals[["Amount"]], on="Date").rename(columns={"Amount": "Contract Revenue"})
-contract_revenue_and_costs_monthly["% Cost"] = contract_revenue_and_costs_monthly["Contract Revenue"] / contract_revenue_and_costs_monthly["Cost"]
-
-ch = alt.Chart(contract_revenue_and_costs_monthly.reset_index(), width=CHART_WIDTH).mark_bar(strokeWidth=10).encode(
-    x="yearmonth(Date):O",
-    y=alt.Y(
-        "% Cost",
-        scale=alt.Scale(domain=[0, 1.2]),
-        axis=alt.Axis(format='%')
-    ),
-    tooltip=alt.Tooltip("% Cost", format=".0%")
-).interactive()
-
-ln = alt.Chart(pd.DataFrame({'y': [1]})).mark_rule(strokeDash=[10, 10]).encode(y='y')
-ch + ln
-```
-
-+++ {"user_expressions": []}
-
-## Cloud costs recovery
-
-Below are our monthly cloud costs across all providers for our communities.
-We pass-through cloud costs directly to communities in invoices, so we also track the revenue we've generated to make up for these costs.
-
-```{warning} These might not be correct
-It's possible that these numbers are not correct because we have not yet set up the right billing categories.
-In particular, some of our cloud cost recovery is merged with our fees in a single monthly invoice.
-
-See https://github.com/2i2c-org/team-compass/issues/663 for an issue tracking this.
-```
-
-```{code-cell} ipython3
-:tags: [remove-cell]
-
-# Group by month and separate out costs vs. revenues
-cloud_costs = pd.melt(rebillable[["Date", "Cost", "Revenue"]], id_vars="Date", var_name="Kind").query("value != 0")
-cloud_costs = cloud_costs.groupby(["Kind"]).resample("M", on="Date").sum(numeric_only=True).reset_index()
-
-# Multiple by -1 so that costs become negative and revenue becomes positive
-cloud_costs.loc[:, "value"] *= -1
-
-# Pivot so that we can compare revenue to cost per month
-cloud_costs = pd.pivot(cloud_costs, index="Date", columns="Kind", values="value")
-cloud_costs["Net"] = cloud_costs["Revenue"] + cloud_costs["Cost"]
-
-# Now move back to long-form so we can plot
-cloud_costs = cloud_costs.stack()
-cloud_costs.name = "value"
-cloud_costs = cloud_costs.reset_index()
-```
-
-```{code-cell} ipython3
-:tags: [remove-input, remove-stderr, remove-stdout]
-
-alt.Chart(cloud_costs, title="Cloud costs and recovery").mark_bar().encode(
-    column=alt.Column("Date"),
-    x=alt.X("Kind", scale=alt.Scale(domain=["Cost", "Revenue", "Net"])),
-    y="value",
-    tooltip=["Kind", alt.Tooltip("value", format="$,.2f")],
-    color=alt.Color("Kind", scale=alt.Scale(domain=["Cost", "Revenue", "Net"], range=["red", "green", "grey"])),
-).interactive()
-```
-
-+++ {"user_expressions": []}
-
-## Accounting tables
-
-Summary tables of revenue and cost by major category.
-
-```{code-cell} ipython3
-:tags: [remove-cell]
-
-def split_accounting_category(df):
-    for ix, irow in df.iterrows():
-        parts = irow["Account"].split(" ", 1)[-1].split(":", 1)
-        if len(parts) == 1:
-            parts = ["Misc"] + parts
-        df.loc[ix, "Category"] = parts[0]
-        df.loc[ix, "Child"] = parts[1]
-    return df
-    
-def visualize_df_with_sum(df, summary=True):
-    # So we don't over-write the DF
-    df = df.copy()
-
-    if summary is True:
-        # Add summary statistics
-        df.loc["Sum", :] = df.sum(0).values
-        style = df.style
-
-        # Highlight our summary rows
-        def highlight_summaries(row):
-            total_style = pd.Series("font-weight: bold;", index=["Sum"])
-            return total_style
-        style = style.apply(highlight_summaries, axis=0)
-    else:
-        style = df.style
-    # Dollar formatting
-    style = style.format("${:,.0f}", na_rep="$0")
-    style = style.format_index("{:%B, %Y}", axis=1)
-
-    return style
-```
-
-+++ {"user_expressions": []}
-
-### Overview
-
-```{code-cell} ipython3
-:tags: [remove-input]
-
-overall_summary_table = overall_summary.pivot(index="Category", values="value", columns="Date").loc[["Revenue", "Cost", "Net", "Cumulative"]]
-overall_summary_table = overall_summary_table.rename(index={"Cumulative": "Cash on Hand (end of month)"})
-visualize_df_with_sum(overall_summary_table, summary=False)
-```
-
-+++ {"user_expressions": []}
-
-### Cost
-
-```{code-cell} ipython3
-:tags: [remove-input]
-
-# Group by month
-costs_summary = costs.groupby(["Category"]).resample("M", on="Date").sum("Cost")["Cost"]
-
-# Unstack date
-costs_summary = costs_summary.unstack("Date")
-
-# Sort from least to most expensive and then by category
-costs_summary = costs_summary.loc[costs_summary.sum(1).sort_values().index]
-costs_summary = costs_summary.sort_index()
-
-visualize_df_with_sum(costs_summary)
-```
-
-+++ {"user_expressions": []}
-
-#### Anticipated annual total costs
-
-An expected annual total, used to calculate our expected operating costs over a single year.
-Calculated by either summing across the last 12 months.
-For months that do not have 12 previous months of historical data, we calculate the sum of the available data, and then add `mean(available_data) * n_missing_months`.
-This might introduce some skew into our data for months with unusually high costs.
-
-```{code-cell} ipython3
-:tags: [remove-input]
-
-def calculate_annual_average(series):
-    n_entries = len(series)
-    sum_total = series.sum()
-    n_extra = 12 - len(series)
-    return sum_total + series.mean() * n_extra
-
-# Remove the excluded categories since we're just estimating our costs here
-monthly_cost_total = costs_summary.query("Category not in @exclude_cost_categories").copy()
-monthly_cost_total = monthly_cost_total.sum(0)
-monthly_cost_total = (monthly_cost_total.rolling(12, min_periods=1).apply(calculate_annual_average).to_frame("Expected Annual Costs").T)
-style = monthly_cost_total.style.format("${:,.0f}", na_rep="$0")
-style.format_index("{:%B, %Y}", axis=1)
-```
-
-+++ {"user_expressions": []}
-
-### Revenue
-
-_This excludes revenue we have invoiced but not yet received payment for._
-
-```{code-cell} ipython3
-:tags: [remove-input]
-
-# Sum by category and unstack
-revenue_summary = revenue_monthly.groupby(["Date", "Category"]).sum("Amount Paid").loc[:, "Amount Paid"].unstack("Date")
-
-# Only show the months that we have accounting information for
-# This way we know it's had time to be updated
-revenue_summary = revenue_summary.loc[:, costs_summary.columns[0]:]
-
-visualize_df_with_sum(revenue_summary)
 ```

--- a/book/finances.md
+++ b/book/finances.md
@@ -16,8 +16,8 @@ kernelspec:
 
 # Accounting and finance
 
-This analyses two data streams that represent 2i2c's financial activity.[^1]
-It is meant to be used for both financial analysis and projection, as well as defining a few KPIs for sustainability and efficiency.
+This page summarizes 2i2c's financial picture, as well as our major cost and revenue trends.[^1]
+Its goal is to provide transparency about how money is flowing through our organization.
 
 Last updated: **{sub-ref}`today`**
 
@@ -70,6 +70,9 @@ from IPython.display import Markdown, display
 +++ {"user_expressions": []}
 
 ## Summary of cost and revenue
+
+This provides a high-level overview of our revenue and expenses over time.
+Months with a large influx of cash correspond to new grants that we have received, that are generally paid in batch amounts.
 
 ```{code-cell} ipython3
 :tags: [remove-cell]


### PR DESCRIPTION
This simplifies our accounting page so that it has a bit less custom plotting on it, now that we have a more maintainable visualization of some of this data for _internal_ purposes [at this airtable interface](https://airtable.com/invite/l?inviteId=invF192DfoKa5xqqY&inviteToken=ef8865617dd3b6ebbb01b753fa2de0d231f1a7f526b6fe07d3cf88c12a418f5f&utm_medium=email&utm_source=product_team&utm_content=transactional-alerts). Here are the major changes:

- This fixes our accounting page to reflect some changes to column names. closes https://github.com/2i2c-org/kpis/issues/15
- Removes some of the plots that were doing more custom visualization, since they were more complex and brittle.
- Generally refactors this page to focus on the most important summary plots and explains why we include them for public visibility.