### PR TITLE
Use key communities list from team compass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 # Data files bundled with this tool that we don't want to check in
 book/data/github-activity.csv
 book/data/hub-activity.csv
+book/data/key-communities.toml
 
 # A place to manually store data we use as part of data updating
 book/scripts/_data/

--- a/book/conf.py
+++ b/book/conf.py
@@ -1,7 +1,7 @@
 title = "2i2c KPIs"
 extensions = ["myst_nb", "sphinx_design", "sphinx_togglebutton", "sphinx.ext.intersphinx"]
 
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints", "data/**"]
 only_build_toc_files = True
 
 myst_enable_extensions = [
@@ -25,3 +25,19 @@ intersphinx_mapping = {
     "infra": ("https://infrastructure.2i2c.org/en/latest/", None),
     "tc": ("https://compass.2i2c.org/en/latest/", None),
 }
+
+# Download key communities CSV file if it isn't there
+from pathlib import Path
+import urllib.request
+
+# URL of the file to download
+file_url = 'https://compass.2i2c.org/_downloads/8fa10f7f661246ec4fbe1515e254aa6d/key-communities.toml'
+file_local = Path("data/key-communities.toml")
+
+# Open the URL
+if not file_local.exists():
+    with urllib.request.urlopen(file_url) as response:
+        # Read the content of the response
+        file_content = response.read()
+        file_local.write_bytes(file_content)
+        print(f"Downloaded new key communities file to: {file_local}")

--- a/book/data/key-communities.yml
+++ b/book/data/key-communities.yml
@@ -1,6 +1,0 @@
-- "binder-examples"
-- "jupyter"
-- "jupyterhub"
-- "jupyterlab"
-- "executablebooks"
-- "2i2c-org"

--- a/book/upstream.md
+++ b/book/upstream.md
@@ -42,6 +42,7 @@ import json
 from ast import literal_eval
 from IPython.display import Markdown
 from urllib.parse import quote
+from tomlkit import parse
 ```
 
 +++ {"tags": ["remove-cell"]}
@@ -52,7 +53,8 @@ from urllib.parse import quote
 :tags: [remove-cell]
 
 # Load data that we'll use for visualization
-communities = safe_load(Path("data/key-communities.yml").read_text())
+with Path("data/key-communities.toml").open() as ff:
+    communities = parse(ff.read())["communities"]
 communities = list(filter(lambda a: a != "2i2c-org", communities))
 team = safe_load(Path("data/team.yml").read_text())
 ```
@@ -168,6 +170,7 @@ def visualize_over_time(df, on="updatedAt", title=""):
 
 Key upstream communities are communities that 2i2c utilizes, empowers, and supports.
 We try to use technology from these communities wherever possible, and put additional team resources towards making upstream contributions and providing general support.
+See [the 2i2c team compass](inv:tc#open-source/key-communities) for more information about this.
 
 Below are 2i2c's key upstream communities:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ linkify-it-py
 rich
 sphinx-design
 sphinx-togglebutton
+tomlkit
 
 # For developing
 itables


### PR DESCRIPTION
This updates our kpis dashboard to use the key communities list in our Team Compass. It'll also result in updating these dashboard per the new additions in:

- https://github.com/2i2c-org/meta/issues/830

Gonna merge this one in and see if the CI/CD works as expected!