### PR TITLE
Add map plot to our cloud KPIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ dmypy.json
 book/data/github-activity.csv
 book/data/hub-activity.csv
 book/data/key-communities.toml
+book/data/airtable-communities.csv
 
 # A place to manually store data we use as part of data updating
 book/scripts/_data/

--- a/book/scripts/download_airtable_data.py
+++ b/book/scripts/download_airtable_data.py
@@ -1,0 +1,50 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %%
+from pyairtable import Api
+import pandas as pd
+import os
+from pathlib import Path
+
+# Define here based on whether we're interactive
+if "__file__" in globals():
+    here = Path(__file__).parent
+else:
+    here = Path(".")
+
+# %%
+# This API key is a secret in our KPIs repository as well
+api_key = os.environ.get("AIRTABLE_API_KEY")
+if not api_key:
+    raise ValueError("Missing AIRTABLE_API_KEY")
+
+base_id = 'appbjBTRIbgRiElkr'
+table_id = 'tblYGygEo5PQBSUYt'
+view_name = 'viw2F6xVWJujWKCuj'
+
+## Load in airtable
+api = Api(api_key)
+table = api.table(base_id, table_id)
+records = table.all(view=view_name)
+df = pd.DataFrame.from_records((r['fields'] for r in records))
+
+# %% [markdown]
+# Write to a CSV file (not checked into git)
+
+# %%
+out_file = Path(here / "../data/airtable-communities.csv" )
+df.to_csv(out_file, index=False)
+print(f"Finished downloading latest AirTable community data to {out_file.resolve()}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,23 @@
 # To run the code
 altair
-myst-nb
-pyairtable
-pandas
+geopandas
+geopy
 ghapi
 github-activity
-git+https://github.com/2i2c-org/sphinx-2i2c-theme
+ipywidgets
 linkify-it-py
+matplotlib
+myst-nb
+pandas
+pyairtable
+pyarrow
 rich
+shapely
+git+https://github.com/2i2c-org/sphinx-2i2c-theme
 sphinx-design
 sphinx-togglebutton
 tomlkit
+vega_datasets
 
 # For developing
 itables


### PR DESCRIPTION
This adds a cloud plot to our KPIs website, so that we can visualize the geographic distribution of our communities.

It uses a hand-coded "city" location that we define in our airtable for each community, and geolocates each one using the default geopandas Nomanitim geocoder. It then merges this with our "monthly active users" data based on the `hub domain` field.

There's a lot we could improve here but wanted to get this up as a start.