### PR TITLE
Update the script to clean the CSS accounting data

### DIFF
--- a/book/scripts/download_airtable_data.py
+++ b/book/scripts/download_airtable_data.py
@@ -26,10 +26,12 @@ else:
     here = Path(".")
 
 # %%
+import sys
+path_twoc = Path("../").resolve()
+sys.path.append(str(path_twoc))
+import twoc
 # This API key is a secret in our KPIs repository as well
-api_key = os.environ.get("AIRTABLE_API_KEY")
-if not api_key:
-    raise ValueError("Missing AIRTABLE_API_KEY")
+api_key = twoc.api_key()
 
 # These correspond to AirTable URLs of the form:
 #   airtable.com/{{ BASE ID }}/{{ TABLE ID }}/{{VIEW ID}}

--- a/book/twoc/__init__.py
+++ b/book/twoc/__init__.py
@@ -2,6 +2,9 @@
 A helper module to quickly generate visualizations that use 2i2c's colors and style.
 Importing this modifies plotly defaults to use these colors.
 """
+import os
+
+# Colors for our brand
 colors = dict(
     bigblue = "#1D4EF5",
     paleblue = "#F2F5FC",
@@ -23,3 +26,10 @@ def set_plotly_defaults():
     custom_template.layout.colorway = [colors["bigblue"], colors["coral"], colors["lightgreen"], colors["magenta"], colors["pink"], colors["yellow"]]
     pio.templates["custom_theme"] = custom_template
     pio.templates.default = "custom_theme"
+
+# This API key is a secret in our KPIs repository as well
+def api_key(env="AIRTABLE_API_KEY"):
+    api_key = os.environ.get(env)
+    if not api_key:
+        raise ValueError("Missing value for key variable: {env}")
+    return api_key


### PR DESCRIPTION
We use a geolocator to get the latitude and longitude of the city of each community before displaying on the map. However this was very buggy and resulted in a bunch of maintenance (in-part because the geocoder services APIs are not well-maintained). This PR makes the following changes to make it more resilient and maintainable:

- Removes the auto-geocoding code.
- Adds [a new `Locations` AirTable](https://airtable.com/appbjBTRIbgRiElkr/tblNiMH0gYRVhVdhE/viwYjmYFRWWJnrv8Y?blocks=hide) that contains an entry for each city that we're working with
	- I added a latitude and longitude for each, and did a one-time geolocate step pasting in the data from Claude
- Linked each "Location" entry with the "Location" field in [our Communities airtable](https://airtable.com/appbjBTRIbgRiElkr/tblYGygEo5PQBSUYt/viwXdwNCv2UAKAFj1?blocks=hide)
- Updated our cloud script to use the lat/lon from this airtable directly