### PR TITLE
Add github token to action for sphinx build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,8 @@ jobs:
         run: sphinx-build -v -b dirhtml book book/_build/dirhtml
         env:
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }} 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
       # Encrypt pages that are only meant for team consumption
       - name: Encrypt some pages

--- a/book/people.md
+++ b/book/people.md
@@ -85,7 +85,10 @@ tags: [remove-cell]
 ---
 # Use the GH CLI to print all of the records in our time off table
 cmd = "gh project item-list 39 --owner 2i2c-org -L 500 --format json"
-out = run(cmd.split(), text=True, capture_output=True)
+try:
+    out = run(cmd.split(), text=True, capture_output=True, check=True)
+except Exception:
+    raise ValueError(out.stderr)
 
 # Strip the output of all color codes and parse it as JSON, then a dataframe
 def strip_ansi(text):


### PR DESCRIPTION
We are using the GitHub CLI in our workflow, but I think we need to [manually specify the token in the environment](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows) for this to work. So this uses the token from the repository's access and adds a check to make sure the `gh` command passes as expected.