### PR TITLE
Use lattitude and longitude from AirTable base

### DIFF
--- a/book/scripts/download_airtable_data.py
+++ b/book/scripts/download_airtable_data.py
@@ -35,6 +35,7 @@ if not api_key:
 #   airtable.com/{{ BASE ID }}/{{ TABLE ID }}/{{VIEW ID}}
 views = [
     ("communities", "appbjBTRIbgRiElkr", "tblYGygEo5PQBSUYt", "viw2F6xVWJujWKCuj"),
+    ("locations", "appbjBTRIbgRiElkr", "tblNiMH0gYRVhVdhE", "viwYjmYFRWWJnrv8Y"),
     ("accounting", "appbjBTRIbgRiElkr", "tblNjmVbPaVmC7wc3", "viw1daKSu2dTcd5lg"),
     ("contracts", "appbjBTRIbgRiElkr", "tbliwB70vYg3hlkb1", "viwWPJhcFbXUJZUO6"),
     ("leads", "appbjBTRIbgRiElkr", "tblmRU6U53i8o7z2I", "viw8xzzSXk8tPwBho"),
@@ -46,7 +47,9 @@ for (name, base_id, table_id, view_id) in views:
     table = api.table(base_id, table_id)
     records = table.all(view=view_id)
     print(f"Downloading AirTable data from https://airtable.com/{base_id}/{table_id}/{view_id}...")
-    df = pd.DataFrame.from_records((r["fields"] for r in records))
+    # Add the AirTable ID for easy indexing later
+    data = [r["fields"] | {"aid": r["id"]} for r in records]
+    df = pd.DataFrame.from_records(data)
     
     # %% [markdown]
     # Write to a CSV file (not checked into git)


### PR DESCRIPTION
We use a geolocator to get the latitude and longitude of the city of each community before displaying on the map. However this was very buggy and resulted in a bunch of maintenance (in-part because the geocoder services APIs are not well-maintained). This PR makes the following changes to make it more resilient and maintainable:

- Removes the auto-geocoding code.
- Adds [a new `Locations` AirTable](https://airtable.com/appbjBTRIbgRiElkr/tblNiMH0gYRVhVdhE/viwYjmYFRWWJnrv8Y?blocks=hide) that contains an entry for each city that we're working with
	- I added a latitude and longitude for each, and did a one-time geolocate step pasting in the data from Claude
- Linked each "Location" entry with the "Location" field in [our Communities airtable](https://airtable.com/appbjBTRIbgRiElkr/tblYGygEo5PQBSUYt/viwXdwNCv2UAKAFj1?blocks=hide)
- Updated our cloud script to use the lat/lon from this airtable directly