### PR TITLE
Store pre and post encryption build artifact as artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,13 @@ jobs:
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }} 
           GH_TOKEN: ${{ secrets.TOKEN_GITHUB_API_READONLY }}
 
+      # Upload artifact for looking at later
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          # Upload entire build output
+          name: pre-encrypted-website
+          path: 'book/_build/'
 
       # Encrypt pages that are only meant for team consumption
       - name: Encrypt some pages
@@ -88,6 +95,7 @@ jobs:
         if: always()
         with:
           # Upload entire build output
+          name: encrypted-website
           path: 'book/_build/'
 
       # Upload to GH Pages


### PR DESCRIPTION
This will allow us to inspect them and understand if a problem is due to encryption or something else.